### PR TITLE
Add typo3/cms:extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "header_image"
+			"extension-key": "rte_ckeditor_automails"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,10 @@
 	"keywords": ["TYPO3 CMS"],
 	"require": {
 		"typo3/cms-core": ">=8.7.0"
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "header_image"
+		}
 	}
 }


### PR DESCRIPTION
Add extension-key in composer.json, otherwise composer calls will throw deprecation warnings